### PR TITLE
Add basic tests for regression

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,3 @@ include *.md
 
 # Include the license file
 include LICENSE.txt
-
-# Include the data files
-recursive-include data *

--- a/abuseipdb/package_data.dat
+++ b/abuseipdb/package_data.dat
@@ -1,1 +1,0 @@
-some data

--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ setup(
     # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files
     #
     # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-    data_files=[('my_data', ['data/data_file'])],  # Optional
+    data_files=[],  # Optional
 
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -20,3 +20,18 @@ class LegacyTestCase(TestCase):
         self.reset_configuration()
         abuseipdb.configure_api_key(None)
         assert Parameters.get_config() == {}
+
+    def test_check_ip__no_api_key_configured(self):
+        self.reset_configuration()
+        with self.assertRaises(KeyError):
+            abuseipdb.check_ip(ip='192.0.2.123')
+
+    def test_check_cidr__no_api_key_configured(self):
+        self.reset_configuration()
+        with self.assertRaises(KeyError):
+            abuseipdb.check_cidr(cidr='192.0.2.123')
+
+    def test_report_ip__no_api_key_configured(self):
+        self.reset_configuration()
+        with self.assertRaises(KeyError):
+            abuseipdb.report_ip(ip='192.0.2.123', categories="22")

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -18,8 +18,8 @@ class LegacyTestCase(TestCase):
 
     def test_configure_api_key__no_key_provided(self):
         self.reset_configuration()
-        abuseipdb.configure_api_key(None)
-        assert Parameters.get_config() == {}
+        with self.assertRaises(ValueError):
+            abuseipdb.configure_api_key(None)
 
     def test_check_ip__no_api_key_configured(self):
         self.reset_configuration()

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -26,6 +26,12 @@ class LegacyTestCase(TestCase):
         with self.assertRaises(KeyError):
             abuseipdb.check_ip(ip='192.0.2.123')
 
+    def test_check_ip__no_ip_address_provided(self):
+        self.reset_configuration()
+        abuseipdb.configure_api_key('some_API_key')
+        with self.assertRaises(ValueError):
+            abuseipdb.check_ip()
+
     @patch('unirest.get')
     def test_check_ip(self, mock):
         self.reset_configuration()
@@ -37,6 +43,12 @@ class LegacyTestCase(TestCase):
         self.reset_configuration()
         with self.assertRaises(KeyError):
             abuseipdb.check_cidr(cidr='192.0.2.123')
+
+    def test_check_cidr__no_cidr_network_provided(self):
+        self.reset_configuration()
+        abuseipdb.configure_api_key('some_API_key')
+        with self.assertRaises(ValueError):
+            abuseipdb.check_cidr()
 
     @patch('unirest.get')
     def test_check_cidr(self, mock):
@@ -51,6 +63,18 @@ class LegacyTestCase(TestCase):
         self.reset_configuration()
         with self.assertRaises(KeyError):
             abuseipdb.report_ip(ip='192.0.2.123', categories="22")
+
+    def test_report_ip__no_ip_address_provided(self):
+        self.reset_configuration()
+        abuseipdb.configure_api_key('some_API_key')
+        with self.assertRaises(ValueError):
+            abuseipdb.report_ip(categories="22")
+
+    def test_report_ip__no_categories_provided(self):
+        self.reset_configuration()
+        abuseipdb.configure_api_key('some_API_key')
+        with self.assertRaises(ValueError):
+            abuseipdb.report_ip(ip='192.0.2.123')
 
     @patch('unirest.get')
     def test_report_ip(self, mock):

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -26,12 +26,35 @@ class LegacyTestCase(TestCase):
         with self.assertRaises(KeyError):
             abuseipdb.check_ip(ip='192.0.2.123')
 
+    @patch('unirest.get')
+    def test_check_ip(self, mock):
+        self.reset_configuration()
+        abuseipdb.configure_api_key('some_API_key')
+        abuseipdb.check_ip(ip='192.0.2.123')
+        mock.assert_called_once_with('https://www.abuseipdb.com/check/192.0.2.123/json?key=some_API_key&days=30')
+
     def test_check_cidr__no_api_key_configured(self):
         self.reset_configuration()
         with self.assertRaises(KeyError):
             abuseipdb.check_cidr(cidr='192.0.2.123')
 
+    @patch('unirest.get')
+    def test_check_cidr(self, mock):
+        self.reset_configuration()
+        abuseipdb.configure_api_key('some_API_key')
+        abuseipdb.check_cidr(cidr='192.0.2.0/24')
+        # This URL looks wrong, but the APIv1 documentation doesn't indicate,
+        # that the / needs to be encoded.
+        mock.assert_called_once_with('https://www.abuseipdb.com/check-block/json?key=some_API_key&network=192.0.2.0/24&days=30')
+
     def test_report_ip__no_api_key_configured(self):
         self.reset_configuration()
         with self.assertRaises(KeyError):
             abuseipdb.report_ip(ip='192.0.2.123', categories="22")
+
+    @patch('unirest.get')
+    def test_report_ip(self, mock):
+        self.reset_configuration()
+        abuseipdb.configure_api_key('some_API_key')
+        abuseipdb.report_ip(ip='192.0.2.123', categories="22")
+        mock.assert_called_once_with('https://www.abuseipdb.com/report/json?key=some_API_key&category=22&comment=&ip=192.0.2.123')

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -1,7 +1,22 @@
 from unittest import TestCase
 
+import abuseipdb
+from abuseipdb.parameters import Parameters
+from mock import patch
+
 
 class LegacyTestCase(TestCase):
 
-    def test_tox_configuration_works(self):
-        pass
+    def reset_configuration(self):
+        # This is required to test the configuration isolated
+        Parameters.configuration = {}
+
+    def test_configure_api_key__key_provided(self):
+        self.reset_configuration()
+        abuseipdb.configure_api_key('some API key')
+        assert Parameters.get_config() == {'API_KEY': 'some API key'}
+
+    def test_configure_api_key__no_key_provided(self):
+        self.reset_configuration()
+        abuseipdb.configure_api_key(None)
+        assert Parameters.get_config() == {}

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -1,0 +1,7 @@
+from unittest import TestCase
+
+
+class LegacyTestCase(TestCase):
+
+    def test_tox_configuration_works(self):
+        pass

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -7,6 +7,10 @@ from mock import patch
 
 class LegacyTestCase(TestCase):
 
+    # IP addresses from TEST-NET-1 according to RFC 5737
+    TEST_IP_ADDRESS = '192.0.2.123'
+    TEST_CIDR_NETWORK = '192.0.2.0/24'
+
     def reset_configuration(self):
         # This is required to test the configuration isolated
         Parameters.configuration = {}
@@ -24,7 +28,7 @@ class LegacyTestCase(TestCase):
     def test_check_ip__no_api_key_configured(self):
         self.reset_configuration()
         with self.assertRaises(KeyError):
-            abuseipdb.check_ip(ip='192.0.2.123')
+            abuseipdb.check_ip(ip=self.TEST_IP_ADDRESS)
 
     def test_check_ip__no_ip_address_provided(self):
         self.reset_configuration()
@@ -36,20 +40,20 @@ class LegacyTestCase(TestCase):
     def test_check_ip(self, mock):
         self.reset_configuration()
         abuseipdb.configure_api_key('some_API_key')
-        abuseipdb.check_ip(ip='192.0.2.123')
+        abuseipdb.check_ip(ip=self.TEST_IP_ADDRESS)
         mock.assert_called_once_with('https://www.abuseipdb.com/check/192.0.2.123/json?key=some_API_key&days=30')
 
     @patch('unirest.get')
     def test_check_ip__with_different_days(self, mock):
         self.reset_configuration()
         abuseipdb.configure_api_key('some_API_key')
-        abuseipdb.check_ip(ip='192.0.2.123', days='90')
+        abuseipdb.check_ip(ip=self.TEST_IP_ADDRESS, days='90')
         mock.assert_called_once_with('https://www.abuseipdb.com/check/192.0.2.123/json?key=some_API_key&days=90')
 
     def test_check_cidr__no_api_key_configured(self):
         self.reset_configuration()
         with self.assertRaises(KeyError):
-            abuseipdb.check_cidr(cidr='192.0.2.123')
+            abuseipdb.check_cidr(cidr=self.TEST_CIDR_NETWORK)
 
     def test_check_cidr__no_cidr_network_provided(self):
         self.reset_configuration()
@@ -61,7 +65,7 @@ class LegacyTestCase(TestCase):
     def test_check_cidr(self, mock):
         self.reset_configuration()
         abuseipdb.configure_api_key('some_API_key')
-        abuseipdb.check_cidr(cidr='192.0.2.0/24')
+        abuseipdb.check_cidr(cidr=self.TEST_CIDR_NETWORK)
         # This URL looks wrong, but the APIv1 documentation doesn't indicate,
         # that the / needs to be encoded.
         mock.assert_called_once_with('https://www.abuseipdb.com/check-block/json?key=some_API_key&network=192.0.2.0/24&days=30')
@@ -70,7 +74,7 @@ class LegacyTestCase(TestCase):
     def test_check_cidr__with_different_days(self, mock):
         self.reset_configuration()
         abuseipdb.configure_api_key('some_API_key')
-        abuseipdb.check_cidr(cidr='192.0.2.0/24', days='90')
+        abuseipdb.check_cidr(cidr=self.TEST_CIDR_NETWORK, days='90')
         # This URL looks wrong, but the APIv1 documentation doesn't indicate,
         # that the / needs to be encoded.
         mock.assert_called_once_with('https://www.abuseipdb.com/check-block/json?key=some_API_key&network=192.0.2.0/24&days=90')
@@ -78,7 +82,7 @@ class LegacyTestCase(TestCase):
     def test_report_ip__no_api_key_configured(self):
         self.reset_configuration()
         with self.assertRaises(KeyError):
-            abuseipdb.report_ip(ip='192.0.2.123', categories="22")
+            abuseipdb.report_ip(ip=self.TEST_IP_ADDRESS, categories="22")
 
     def test_report_ip__no_ip_address_provided(self):
         self.reset_configuration()
@@ -90,20 +94,20 @@ class LegacyTestCase(TestCase):
         self.reset_configuration()
         abuseipdb.configure_api_key('some_API_key')
         with self.assertRaises(ValueError):
-            abuseipdb.report_ip(ip='192.0.2.123')
+            abuseipdb.report_ip(ip=self.TEST_IP_ADDRESS)
 
     @patch('unirest.get')
     def test_report_ip(self, mock):
         self.reset_configuration()
         abuseipdb.configure_api_key('some_API_key')
-        abuseipdb.report_ip(ip='192.0.2.123', categories="22")
+        abuseipdb.report_ip(ip=self.TEST_IP_ADDRESS, categories="22")
         mock.assert_called_once_with('https://www.abuseipdb.com/report/json?key=some_API_key&category=22&comment=&ip=192.0.2.123')
 
     @patch('unirest.get')
     def test_report_ip__with_some_comment(self, mock):
         self.reset_configuration()
         abuseipdb.configure_api_key('some_API_key')
-        abuseipdb.report_ip(ip='192.0.2.123', categories="22", comment="Some comment")
+        abuseipdb.report_ip(ip=self.TEST_IP_ADDRESS, categories="22", comment="Some comment")
         # This URL looks wrong, but the APIv1 documentation doesn't indicate,
         # that the comment needs to be encoded.
         mock.assert_called_once_with('https://www.abuseipdb.com/report/json?key=some_API_key&category=22&comment=Some comment&ip=192.0.2.123')

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -13,8 +13,8 @@ class LegacyTestCase(TestCase):
 
     def test_configure_api_key__key_provided(self):
         self.reset_configuration()
-        abuseipdb.configure_api_key('some API key')
-        assert Parameters.get_config() == {'API_KEY': 'some API key'}
+        abuseipdb.configure_api_key('some_API_key')
+        assert Parameters.get_config() == {'API_KEY': 'some_API_key'}
 
     def test_configure_api_key__no_key_provided(self):
         self.reset_configuration()

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -39,6 +39,13 @@ class LegacyTestCase(TestCase):
         abuseipdb.check_ip(ip='192.0.2.123')
         mock.assert_called_once_with('https://www.abuseipdb.com/check/192.0.2.123/json?key=some_API_key&days=30')
 
+    @patch('unirest.get')
+    def test_check_ip__with_different_days(self, mock):
+        self.reset_configuration()
+        abuseipdb.configure_api_key('some_API_key')
+        abuseipdb.check_ip(ip='192.0.2.123', days='90')
+        mock.assert_called_once_with('https://www.abuseipdb.com/check/192.0.2.123/json?key=some_API_key&days=90')
+
     def test_check_cidr__no_api_key_configured(self):
         self.reset_configuration()
         with self.assertRaises(KeyError):
@@ -58,6 +65,15 @@ class LegacyTestCase(TestCase):
         # This URL looks wrong, but the APIv1 documentation doesn't indicate,
         # that the / needs to be encoded.
         mock.assert_called_once_with('https://www.abuseipdb.com/check-block/json?key=some_API_key&network=192.0.2.0/24&days=30')
+
+    @patch('unirest.get')
+    def test_check_cidr__with_different_days(self, mock):
+        self.reset_configuration()
+        abuseipdb.configure_api_key('some_API_key')
+        abuseipdb.check_cidr(cidr='192.0.2.0/24', days='90')
+        # This URL looks wrong, but the APIv1 documentation doesn't indicate,
+        # that the / needs to be encoded.
+        mock.assert_called_once_with('https://www.abuseipdb.com/check-block/json?key=some_API_key&network=192.0.2.0/24&days=90')
 
     def test_report_ip__no_api_key_configured(self):
         self.reset_configuration()
@@ -82,3 +98,12 @@ class LegacyTestCase(TestCase):
         abuseipdb.configure_api_key('some_API_key')
         abuseipdb.report_ip(ip='192.0.2.123', categories="22")
         mock.assert_called_once_with('https://www.abuseipdb.com/report/json?key=some_API_key&category=22&comment=&ip=192.0.2.123')
+
+    @patch('unirest.get')
+    def test_report_ip__with_some_comment(self, mock):
+        self.reset_configuration()
+        abuseipdb.configure_api_key('some_API_key')
+        abuseipdb.report_ip(ip='192.0.2.123', categories="22", comment="Some comment")
+        # This URL looks wrong, but the APIv1 documentation doesn't indicate,
+        # that the comment needs to be encoded.
+        mock.assert_called_once_with('https://www.abuseipdb.com/report/json?key=some_API_key&category=22&comment=Some comment&ip=192.0.2.123')

--- a/tox.ini
+++ b/tox.ini
@@ -5,5 +5,6 @@ envlist = py27
 [testenv]
 commands = pytest
 deps =
+    py27: mock
     pytest
     unirest

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+skip_missing_interpreters = true
+envlist = py27
+
+[testenv]
+commands = pytest
+deps =
+    pytest
+    unirest


### PR DESCRIPTION
I should have added them right at the start. Unfortunately I introduced an API change with my refactoring. Still I think, it is much cleaner than the print statements.

These tests will be the safety net for all future changes. They uncover that `check_cidr` and `report_ip` can create malformed URL. As Abuse IP DB set the sunset date for APIv1 to 2020-02-01, it doesn't make sense to fix that.