### PR TITLE
Add masking to comment

### DIFF
--- a/abuseipdb/__init__.py
+++ b/abuseipdb/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '2.1.0'  #: the working version
+__version__ = '2.2.1'  #: the working version
 __release__ = '2.0.0'  #: the release version
 
 try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,3 +88,13 @@ class CommandLineTestCase(TestCase):
         mock = self.call_command(
             action='report', ip_address=self.TEST_IP_ADDRESS, categories=[15, 'SSH'], comment=['a', 'comment'])
         mock.assert_called_once_with(ip_address=self.TEST_IP_ADDRESS, categories='15,SSH', comment='a comment')
+
+    def test_report__with_sensitive_comment(self, mock):
+        with patch('pwd.getpwall', return_value=[('username',)]):
+            with patch('socket.gethostname', return_value='hostname'):
+                mock = self.call_command(
+                    action='report', ip_address=self.TEST_IP_ADDRESS, categories=[15, 'SSH'], mask_sensitive_data=True,
+                    comment=["Some", "hostname", "and", "username", "butnothostname", "andnotusername"])
+        mock.assert_called_once_with(
+            ip_address=self.TEST_IP_ADDRESS, categories='15,SSH',
+            comment='Some *host* and *user* butnothostname andnotusername')


### PR DESCRIPTION
This adds a new global command line option, that will mask any sensitive content before pushing to AbuseIP DB.

Currently it masks the following in the comment of the report:
 * The output of `hostname` is replaces with `*host*`
 * Any user name present in `/etc/passwd` is replaced with `*user*`

Currently it is off by default, which can lead to information disclosure. It was left that way, because then the CLI and API behave identical.